### PR TITLE
Replace BCP14 boilerplate

### DIFF
--- a/draft-ecahc-moderation.md
+++ b/draft-ecahc-moderation.md
@@ -96,7 +96,10 @@ after, and subsumes, the moderator team for the IETF discussion list
 
 # Conventions and Definitions
 
-{::boilerplate bcp14-tagged}
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted in their normal English sense; they are shown
+in uppercase for emphasis and clarity.
 
 # Motivation {#motiv}
 

--- a/draft-ecahc-moderation.md
+++ b/draft-ecahc-moderation.md
@@ -124,14 +124,6 @@ has, mostly for historic reasons, a team of moderators that are not
 list administrators and operate by a different set of processes
 {{?RFC9245}}.
 
-Note that the term "moderation" can refer both to *preemptive*
-moderation, where a moderator reviews messages before release
-to the mailing list, and *reactive* moderation, where the moderator
-intervenes after a message has been sent. The IETF mainly practices
-reactive moderation, with a spectrum from gentle reminders on- and
-off-list, all the way to suspension of posting rights and other ways
-of participating or communicating.
-
 In addition, {{?RFC3683}} defines a process for revoking an
 individual's posting rights to IETF mailing lists following a
 community last-call of a "posting rights" action (PR-action) proposed
@@ -366,6 +358,5 @@ These individuals suggested improvements to this document:
 - Melinda Shore
 - Michael Richardson
 - Rich Salz
-- Joel Halpern
 
 --- back

--- a/draft-ecahc-moderation.md
+++ b/draft-ecahc-moderation.md
@@ -124,6 +124,14 @@ has, mostly for historic reasons, a team of moderators that are not
 list administrators and operate by a different set of processes
 {{?RFC9245}}.
 
+Note that the term "moderation" can refer both to *preemptive*
+moderation, where a moderator reviews messages before release
+to the mailing list, and *reactive* moderation, where the moderator
+intervenes after a message has been sent. The IETF mainly practices
+reactive moderation, with a spectrum from gentle reminders on- and
+off-list, all the way to suspension of posting rights and other ways
+of participating or communicating.
+
 In addition, {{?RFC3683}} defines a process for revoking an
 individual's posting rights to IETF mailing lists following a
 community last-call of a "posting rights" action (PR-action) proposed
@@ -358,5 +366,6 @@ These individuals suggested improvements to this document:
 - Melinda Shore
 - Michael Richardson
 - Rich Salz
+- Joel Halpern
 
 --- back

--- a/draft-ecahc-moderation.md
+++ b/draft-ecahc-moderation.md
@@ -102,6 +102,10 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 document are to be interpreted in their normal English sense; they are shown
 in uppercase for emphasis and clarity.
 
+{:aside}
+> TODO: Get feedback from the community whether this redefinition of BCP14
+> terms in process documents is something they support.
+
 # Motivation {#motiv}
 
 The IETF community has defined general guidelines of conduct for


### PR DESCRIPTION
Just interpret the magic words as plain English, because this is not an interoperability spec. Did not apply bold face.