### PR TITLE
Add to Security Considerations

### DIFF
--- a/draft-ecahc-moderation.md
+++ b/draft-ecahc-moderation.md
@@ -350,7 +350,7 @@ undesired opinions is counteracted by the availability of an appeals
 process, per {{appeals}}.
 
 The actions of the moderation team are intended to limit the likelihood
-of disruptive behaiviour by one IETF participant from discouraging
+of disruptive behavior by one IETF participant from discouraging
 participation by other IETF participants.
 
 # IANA Considerations

--- a/draft-ecahc-moderation.md
+++ b/draft-ecahc-moderation.md
@@ -350,7 +350,7 @@ undesired opinions is counteracted by the availability of an appeals
 process, per {{appeals}}.
 
 The actions of the moderation team are intended to limit the likelihood
-of disruptive behavior by one IETF participant from discouraging
+of disruptive behavior by a few IETF participants from discouraging
 participation by other IETF participants.
 
 # IANA Considerations

--- a/draft-ecahc-moderation.md
+++ b/draft-ecahc-moderation.md
@@ -349,6 +349,10 @@ Potential abuse of the moderation process for the suppression of
 undesired opinions is counteracted by the availability of an appeals
 process, per {{appeals}}.
 
+The actions of the moderation team are intended to limit the likelihood
+of disruptive behaiviour by one IETF participant from discouraging
+participation by other IETF participants.
+
 # IANA Considerations
 
 This document has no IANA actions.


### PR DESCRIPTION
Limit the likelihood of disruptive behaiviour by one IETF participant from discouraging participation by other IETF participants.